### PR TITLE
fix crash backend if github API can't find the username

### DIFF
--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -58,8 +58,14 @@ class UsersModel {
               nbConnections: 0
             }
           } else {
-            body = JSON.parse(body)
-            const thumbnail = body['avatar_url'] || ''
+            let thumbnail = ''
+
+            try {
+              body = JSON.parse(body)
+              thumbnail = body['avatar_url'] || ''
+            } catch (e) {
+              thumbnail = ''
+            }
 
             this._byId[userId] = {
               id: userId,


### PR DESCRIPTION
If username has special chars or spaces, Github response won't have the thumbnail.

We could probably check if `body.message === 'Not Found'` or `response.statusCode === 200` but I decided to use a try catch in case Github returns another error code.

This might be improved of course, feel free to PR :smile: 