### PR TITLE
feat: Download a CSV to handle the $$$

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "angular2-prettyjson": "2.0.5",
     "core-js": "2.4.1",
     "countdown": "2.6.0",
+    "csv-file-creator": "1.0.7",
     "hammerjs": "2.0.8",
     "material-design-icons-iconfont": "3.0.3",
     "ng2-translate": "5.0.0",

--- a/frontend/src/app/features/features.component.html
+++ b/frontend/src/app/features/features.component.html
@@ -26,6 +26,10 @@
     <app-pizzas [locked]="lockOrders"></app-pizzas>
   </md-sidenav-container>
 
+  <button md-mini-fab class="csv-download" (click)="downloadCsv()" [disabled]="!lockOrders">
+    <md-icon>file_download</md-icon>
+  </button>
+
   <button md-mini-fab class="order-summary" (click)="openOrderSummaryDialog()">
     <md-icon>receipt</md-icon>
   </button>

--- a/frontend/src/app/features/features.component.scss
+++ b/frontend/src/app/features/features.component.scss
@@ -40,6 +40,13 @@ md-toolbar.footer {
 .order-summary {
   color: white;
   position: absolute;
-  right: 16px;
+  right: 20px;
   bottom: 80px;
+}
+
+.csv-download {
+  color: white;
+  position: absolute;
+  right: 20px;
+  bottom: 136px;
 }

--- a/frontend/src/app/shared/helpers/date.helper.ts
+++ b/frontend/src/app/shared/helpers/date.helper.ts
@@ -1,0 +1,16 @@
+// adapted from this stackoverflow answer https://stackoverflow.com/a/3552493/2398593
+export function getCurrentDateFormatted() {
+  const monthNames = [
+    'January', 'February', 'March',
+    'April', 'May', 'June', 'July',
+    'August', 'September', 'October',
+    'November', 'December'
+  ];
+
+  const date = new Date();
+  const day = date.getDate();
+  const monthIndex = date.getMonth();
+  const year = date.getFullYear();
+
+  return `${day}-${monthNames[monthIndex]}-${year}`;
+}

--- a/frontend/src/app/shared/states/users/users.selector.ts
+++ b/frontend/src/app/shared/states/users/users.selector.ts
@@ -61,3 +61,30 @@ export function _getFullOrder(store$: Store<IStore>) {
 export function getFullOrder() {
   return _getFullOrder;
 }
+
+export function getFullOrderCsvFormat({ users }: { users: IUserWithPizzas[], totalPrice: number }) {
+  const header = ['Person name', 'Pizza', 'Size', 'Price', 'Pay', 'Change', 'Done ✓ or not yet ✕'];
+
+  // the row index starts at 2 because in a speadsheet, it starts at 1 and we'll have the header
+  let i = 2;
+
+  const data = users.reduce((acc, user) => {
+    user.pizzas.forEach(pizza => {
+      acc.push([
+        user.username,
+        pizza.name,
+        pizza.size,
+        pizza.price,
+        '0',
+        `=E${i}-D${i}`,
+        '✕'
+      ]);
+
+      i++;
+    });
+
+    return acc;
+  }, []);
+
+  return [header, ...data];
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1350,6 +1350,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csv-file-creator@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/csv-file-creator/-/csv-file-creator-1.0.7.tgz#3389261da639f43c1def0d2cd1578c66b9a80259"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -1373,23 +1377,23 @@ dateformat@^1.0.11:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@*, debug@2, debug@2.3.3, debug@^2.1.3, debug@^2.2.0:
+debug@*, debug@2.3.3, debug@^2.1.3, debug@^2.2.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:
     ms "0.7.2"
+
+debug@2, debug@2.6.7, debug@^2.1.1, debug@^2.6.3:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  dependencies:
+    ms "2.0.0"
 
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
-
-debug@2.6.7, debug@^2.1.1, debug@^2.6.3:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -5502,9 +5506,13 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@2.3.2, "typescript@>=2.0.0 <2.3.0":
+typescript@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+
+"typescript@>=2.0.0 <2.3.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
 uglify-js@3.0.x:
   version "3.0.9"
@@ -6062,6 +6070,10 @@ yn@^1.2.0:
   dependencies:
     object-assign "^4.1.1"
 
-zone.js@0.8.10, zone.js@^0.7.2:
+zone.js@0.8.10:
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.10.tgz#6d1b696492c029cdbe808e59e87bbd9491b98aa8"
+
+zone.js@^0.7.2:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.8.tgz#4f3fe8834d44597f2639053a0fa438df34fffded"


### PR DESCRIPTION
Add a download button : 

![pizza-sync-1](https://cloud.githubusercontent.com/assets/4950209/26373793/3b615578-4003-11e7-85ac-b0d5df2f767b.png)

Once the order is complete, the download button is unlocked : 
![pizza-sync-2](https://cloud.githubusercontent.com/assets/4950209/26373812/4f09aefe-4003-11e7-9a97-f0a1a0e6a9cf.png)

And it'll prompt the user if he wants to download a CSV.

Once downloaded, it's easy to manage the :moneybag: :moneybag: :moneybag: for the group !

<hr>

Why not handle that feature into the app ?  
Simply because the app is **not safe** at all. It hasn't been built for that.  
It would be too easy for people to "hack" the app and set that they've already paid for example.

So in order to avoid troubles ... CSV FTW :angel: !