### PR TITLE
Normalize ingredients

### DIFF
--- a/backend/controllers/app.controller.js
+++ b/backend/controllers/app.controller.js
@@ -32,6 +32,10 @@ class AppController {
     return this._appMdl.getUsersModel()
   }
 
+  getIngredientsModel() {
+    return this._appMdl.getIngredientsModel()
+  }
+
   parsePizzaProvider() {
     return new Promise((resolve, reject) => {
       if (this._parsePizzaProviderCache) {
@@ -45,16 +49,19 @@ class AppController {
             const normalizedPizzasAndPizzasCaterogies = {
               pizzeria: pizzasAndPizzasCategories.pizzeria,
               pizzas: normalizeArray(pizzasAndPizzasCategories.pizzas),
-              pizzasCategories: normalizeArray(pizzasAndPizzasCategories.pizzasCategories)
+              pizzasCategories: normalizeArray(pizzasAndPizzasCategories.pizzasCategories),
+              ingredients: normalizeArray(pizzasAndPizzasCategories.ingredients)
             }
 
             this._parsePizzaProviderCache = normalizedPizzasAndPizzasCaterogies
 
             this.getPizzasModel().setNormalizedData(this._parsePizzaProviderCache.pizzas)
             this.getPizzasCategoriesModel().setNormalizedData(this._parsePizzaProviderCache.pizzasCategories)
+            this.getIngredientsModel().setNormalizedData(this._parsePizzaProviderCache.ingredients)
 
             resolve(this._parsePizzaProviderCache)
           })
+          .catch(e => { })
       }
     })
   }

--- a/backend/helpers/normalize.helper.js
+++ b/backend/helpers/normalize.helper.js
@@ -5,6 +5,10 @@
  * @returns {id1: {id: 'id1', ...}}
  */
 function normalizeArray(arr) {
+  if (!arr) {
+    return { byId: {}, allIds: [] }
+  }
+
   return arr.reduce((acc, next) => {
     acc.byId[next.id] = next
     acc.allIds.push(next.id)

--- a/backend/helpers/string.helper.js
+++ b/backend/helpers/string.helper.js
@@ -1,0 +1,11 @@
+/**
+ * cleanIngredientName
+ *
+ * @param {string} ingredientName
+ * @returns {string} The cleaned ingredient name
+ */
+function cleanIngredientName(ingredientName) {
+  return ingredientName.trim().toLowerCase()
+}
+
+module.exports = { cleanIngredientName }

--- a/backend/models/app.model.js
+++ b/backend/models/app.model.js
@@ -4,6 +4,7 @@ const { PizzasModel } = require('./pizzas.model')
 const { PizzasCategoriesModel } = require('./pizzas-categories.model')
 const { OrdersModel } = require('./orders.model')
 const { UsersModel } = require('./users.model')
+const { IngredientsModel } = require('./ingredients.model')
 
 class AppModel {
   constructor() {
@@ -11,6 +12,7 @@ class AppModel {
     this._pizzasCategoriesMdl = new PizzasCategoriesModel()
     this._ordersMdl = new OrdersModel()
     this._usersMdl = new UsersModel()
+    this._ingredientsMdl = new IngredientsModel()
   }
 
   getInitialState() {
@@ -18,7 +20,8 @@ class AppModel {
       pizzas: this._pizzasMdl.getNormalizedData(),
       pizzasCategories: this._pizzasCategoriesMdl.getNormalizedData(),
       users: this._usersMdl.getNormalizedData(),
-      orders: this._ordersMdl.getNormalizedData()
+      orders: this._ordersMdl.getNormalizedData(),
+      ingredients: this._ingredientsMdl.getNormalizedData()
     }
   }
 
@@ -36,6 +39,10 @@ class AppModel {
 
   getUsersModel() {
     return this._usersMdl
+  }
+
+  getIngredientsModel() {
+    return this._ingredientsMdl
   }
 }
 

--- a/backend/models/ingredients.model.js
+++ b/backend/models/ingredients.model.js
@@ -1,0 +1,48 @@
+const { cleanIngredientName } = require('../helpers/string.helper')
+
+class IngredientsModel {
+  constructor() {
+    this._byId = {}
+    this._allIds = []
+
+  }
+
+  static getNewId() {
+    return `ingredientId${IngredientsModel._id++}`
+  }
+
+  static registerIfNewAndGetId(ingredientName) {
+    ingredientName = cleanIngredientName(ingredientName)
+
+    if (IngredientsModel._ingredientsMap.has(ingredientName)) {
+      return IngredientsModel._ingredientsMap.get(ingredientName).id
+    }
+
+    const newId = IngredientsModel.getNewId()
+
+    IngredientsModel._ingredientsMap.set(ingredientName, { id: newId, name: ingredientName })
+
+    return newId
+  }
+
+  static getIngredients() {
+    return Array.from(IngredientsModel._ingredientsMap.values())
+  }
+
+  setNormalizedData({ byId, allIds }) {
+    this._byId = byId
+    this._allIds = allIds
+  }
+
+  getNormalizedData() {
+    return {
+      byId: this._byId,
+      allIds: this._allIds
+    }
+  }
+}
+
+IngredientsModel._id = 0
+IngredientsModel._ingredientsMap = new Map()
+
+module.exports = { IngredientsModel }

--- a/backend/pizzas-providers/parse-pizza-de-l-ormeau.js
+++ b/backend/pizzas-providers/parse-pizza-de-l-ormeau.js
@@ -5,6 +5,7 @@ const { requestOptions } = require('../helpers/http.helper')
 
 const { PizzasModel } = require('../models/pizzas.model')
 const { PizzasCategoriesModel } = require('../models/pizzas-categories.model')
+const { IngredientsModel } = require('../models/ingredients.model')
 
 class PizzaDeLOrmeau {
   constructor() {
@@ -26,7 +27,8 @@ class PizzaDeLOrmeau {
             const res = {
               pizzeria: this._pizzeria,
               pizzas: [],
-              pizzasCategories: []
+              pizzasCategories: [],
+              ingredients: []
             }
 
             const $ = cheerio.load(body)
@@ -54,8 +56,11 @@ class PizzaDeLOrmeau {
                 const pizzaDom = $(pizzasDom[j])
 
                 const pizzaName = pizzaDom.find($('.nom')).children().remove().end().text()
-                const pizzaIngredients = pizzaDom.find($('.composition')).text()
+                const pizzaIngredientsTxt = pizzaDom.find($('.composition')).text()
                 const pizzaPricesDom = pizzaDom.find($('.prix'))
+
+                const pizzaIngredientsTxtArray = pizzaIngredientsTxt.replace('.', '').trim().split(', ')
+                const pizzaIngredients = pizzaIngredientsTxtArray.map(IngredientsModel.registerIfNewAndGetId)
 
                 const pizzaPrices = []
                 pizzaPricesDom.map(k => {
@@ -66,7 +71,7 @@ class PizzaDeLOrmeau {
                 const finalPizza = {
                   id: PizzasModel.getNewId(),
                   name: pizzaName,
-                  ingredients: pizzaIngredients,
+                  ingredientsIds: pizzaIngredients,
                   prices: pizzaPrices
                 }
 
@@ -74,6 +79,8 @@ class PizzaDeLOrmeau {
                 res.pizzas.push(finalPizza)
               })
             })
+
+            res.ingredients = IngredientsModel.getIngredients()
 
             resolve(res)
           }

--- a/frontend/src/app/features/pizzas/pizzas.component.html
+++ b/frontend/src/app/features/pizzas/pizzas.component.html
@@ -11,7 +11,7 @@
           <md-card *ngFor="let pizza of pizzaCategorie.pizzas; trackBy: trackById" fxFlex.xs="97%" fxFlex.gt-sm="47%" fxFlex.gt-md="30%" fxFlex.gt-lg="22%">
             <md-card-title class="color-accent">{{ pizza.name }}</md-card-title>
             <md-card-content>
-              <p>{{ pizza.ingredients }}</p>
+              <p>{{ pizza.ingredients | join:'name' }}</p>
             </md-card-content>
             <md-card-actions fxLayout="row">
               <button md-mini-fab *ngFor="let price of pizza.prices; trackBy: index; let i=index" [disabled]="!price || locked" (click)="addOrder(pizza, i)">

--- a/frontend/src/app/features/pizzas/pizzas.effects.ts
+++ b/frontend/src/app/features/pizzas/pizzas.effects.ts
@@ -11,6 +11,7 @@ import * as PizzasCategoriesActions from 'app/shared/states/pizzas-categories/pi
 import * as UsersActions from 'app/shared/states/users/users.actions';
 import * as OrdersActions from 'app/shared/states/orders/orders.actions';
 import * as UiActions from 'app/shared/states/ui/ui.actions';
+import * as IngredientsActions from 'app/shared/states/ingredients/ingredients.actions';
 
 @Injectable()
 export class PizzasEffects {
@@ -28,6 +29,7 @@ export class PizzasEffects {
               new UsersActions.LoadUsersSuccess(res.users),
               new OrdersActions.LoadOrdersSuccess(res.orders),
               new UiActions.UpdatePizzeriaInformation(res.pizzeria),
+              new IngredientsActions.LoadIngredientsSuccess(res.ingredients)
           ]);
         })
     );

--- a/frontend/src/app/features/pizzas/pizzas.service.ts
+++ b/frontend/src/app/features/pizzas/pizzas.service.ts
@@ -7,6 +7,7 @@ import { IPizzasTable } from 'app/shared/states/pizzas/pizzas.interface';
 import { IPizzasCategoriesTable } from 'app/shared/states/pizzas-categories/pizzas-categories.interface';
 import { IUsersTable } from 'app/shared/states/users/users.interface';
 import { IOrdersTable } from 'app/shared/states/orders/orders.interface';
+import { IIngredientsTable } from 'app/shared/states/ingredients/ingredients.interface';
 
 @Injectable()
 export class PizzasService {
@@ -23,7 +24,8 @@ export class PizzasService {
     pizzas: IPizzasTable,
     pizzasCategories: IPizzasCategoriesTable,
     users: IUsersTable,
-    orders: IOrdersTable
+    orders: IOrdersTable,
+    ingredients: IIngredientsTable
   }> {
     return this.http.get(`${environment.urlBackend}/initial-state`).map((res: Response) => res.json());
   }

--- a/frontend/src/app/shared/interfaces/store.interface.ts
+++ b/frontend/src/app/shared/interfaces/store.interface.ts
@@ -3,6 +3,7 @@ import { IPizzasTable } from 'app/shared/states/pizzas/pizzas.interface';
 import { IPizzasCategoriesTable } from 'app/shared/states/pizzas-categories/pizzas-categories.interface';
 import { IUsersTable } from 'app/shared/states/users/users.interface';
 import { IOrdersTable } from 'app/shared/states/orders/orders.interface';
+import { IIngredientsTable } from 'app/shared/states/ingredients/ingredients.interface';
 
 export interface IStore {
   ui: IUi;
@@ -10,4 +11,5 @@ export interface IStore {
   pizzasCategories: IPizzasCategoriesTable;
   users: IUsersTable;
   orders: IOrdersTable;
+  ingredients: IIngredientsTable;
 }

--- a/frontend/src/app/shared/pipes/join.pipe.ts
+++ b/frontend/src/app/shared/pipes/join.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'join'
+})
+export class JoinPipe implements PipeTransform {
+  transform(arr: any[], nameToPluck: string): any {
+    if (!arr) {
+      return '';
+    }
+
+    return arr
+      .filter(x => typeof x !== 'undefined')
+      .map(x => x[nameToPluck]).join(', ');
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -13,6 +13,7 @@ import {
   MdInputModule, MdListModule, MdProgressSpinnerModule, MdRippleModule, MdSidenavModule,
   MdTabsModule, MdToolbarModule, MdTooltipModule, MdSelectModule
 } from '@angular/material';
+import { JoinPipe } from './pipes/join.pipe';
 
 const MaterialModules = [
   MdButtonModule,
@@ -47,7 +48,7 @@ export const modules = [
   ...MaterialModules
 ];
 
-export const declarations = [];
+export const declarations = [JoinPipe];
 
 @NgModule({
   imports: modules,

--- a/frontend/src/app/shared/states/ingredients/ingredients.actions.ts
+++ b/frontend/src/app/shared/states/ingredients/ingredients.actions.ts
@@ -1,0 +1,12 @@
+import { Action } from '@ngrx/store';
+
+import { IIngredientsTable } from 'app/shared/states/ingredients/ingredients.interface';
+
+export const LOAD_INGREDIENTS_SUCCESS = '[Ingredients] Load ingredients success';
+export class LoadIngredientsSuccess implements Action {
+  readonly type = LOAD_INGREDIENTS_SUCCESS;
+
+  constructor(public payload: IIngredientsTable) { }
+}
+
+export type All = LoadIngredientsSuccess;

--- a/frontend/src/app/shared/states/ingredients/ingredients.initial-state.ts
+++ b/frontend/src/app/shared/states/ingredients/ingredients.initial-state.ts
@@ -1,0 +1,8 @@
+import { IIngredientsTable } from 'app/shared/states/ingredients/ingredients.interface';
+
+export function ingredientsState(): IIngredientsTable {
+  return {
+    byId: { },
+    allIds: []
+  };
+};

--- a/frontend/src/app/shared/states/ingredients/ingredients.interface.ts
+++ b/frontend/src/app/shared/states/ingredients/ingredients.interface.ts
@@ -1,0 +1,9 @@
+export interface IIngredientCommon {
+  id: string;
+  name: string;
+}
+
+export interface IIngredientsTable {
+  byId: { [key: string]: IIngredientCommon };
+  allIds: string[];
+}

--- a/frontend/src/app/shared/states/ingredients/ingredients.reducer.ts
+++ b/frontend/src/app/shared/states/ingredients/ingredients.reducer.ts
@@ -1,0 +1,19 @@
+import { ActionReducer, Action } from '@ngrx/store';
+
+import * as IngredientsActions from 'app/shared/states/ingredients/ingredients.actions';
+import { ingredientsState } from 'app/shared/states/ingredients/ingredients.initial-state';
+import { IIngredientsTable } from 'app/shared/states/ingredients/ingredients.interface';
+
+export function ingredientsReducer(ingredientsTbl = ingredientsState(), action: IngredientsActions.All): IIngredientsTable {
+  switch (action.type) {
+    case IngredientsActions.LOAD_INGREDIENTS_SUCCESS: {
+      return {
+        ...ingredientsTbl,
+        ...action.payload
+      };
+    }
+
+    default:
+      return ingredientsTbl;
+  }
+}

--- a/frontend/src/app/shared/states/pizzas-categories/pizzas-categories.interface.ts
+++ b/frontend/src/app/shared/states/pizzas-categories/pizzas-categories.interface.ts
@@ -1,4 +1,4 @@
-import { IPizzaCommon } from 'app/shared/states/pizzas/pizzas.interface';
+import { IPizzaWithIngredients } from 'app/shared/states/pizzas/pizzas.interface';
 
 export interface IPizzaCategoryCommon {
   id: string;
@@ -12,5 +12,5 @@ export interface IPizzasCategoriesTable {
 }
 
 export interface IPizzaCategoryWithPizzas extends IPizzaCategoryCommon {
-  pizzas: IPizzaCommon[];
+  pizzas: IPizzaWithIngredients[];
 }

--- a/frontend/src/app/shared/states/pizzas-categories/pizzas-categories.selector.ts
+++ b/frontend/src/app/shared/states/pizzas-categories/pizzas-categories.selector.ts
@@ -2,35 +2,42 @@ import { Store } from '@ngrx/store';
 
 import { IStore } from 'app/shared/interfaces/store.interface';
 import { IPizzaCategoryWithPizzas } from 'app/shared/states/pizzas-categories/pizzas-categories.interface';
+import { IPizzaWithIngredients } from 'app/shared/states/pizzas/pizzas.interface';
 
 export function getCategoriesAndPizzas(store$: Store<IStore>) {
   return store$.select(state => {
     return {
       pizzasSearch: state.ui.pizzaSearch,
       pizzas: state.pizzas,
-      pizzasCategories: state.pizzasCategories
+      pizzasCategories: state.pizzasCategories,
+      ingredients: state.ingredients
     };
   })
     .distinctUntilChanged((p, n) =>
       p.pizzasSearch === n.pizzasSearch &&
       p.pizzas === n.pizzas &&
-      p.pizzasCategories === n.pizzasCategories
+      p.pizzasCategories === n.pizzasCategories &&
+      p.ingredients === n.ingredients
     )
-    .map(({ pizzasSearch, pizzas, pizzasCategories }) => {
+    .map(({ pizzasSearch, pizzas, pizzasCategories, ingredients }) => {
       pizzasSearch = pizzasSearch.toLowerCase();
 
       return pizzasCategories
         .allIds
         .map(pizzasCategorieId => {
-          const pizzasCategorie = <IPizzaCategoryWithPizzas>{
+          const pizzasCategorie: IPizzaCategoryWithPizzas = {
             ...pizzasCategories.byId[pizzasCategorieId],
-            ...<IPizzaCategoryWithPizzas>{
-              pizzas: pizzasCategories
-                .byId[pizzasCategorieId]
-                .pizzasIds
-                .map(pizzaId => pizzas.byId[pizzaId])
-                .filter(p => p.name.toLowerCase().includes(pizzasSearch))
-            }
+            pizzas: pizzasCategories
+              .byId[pizzasCategorieId]
+              .pizzasIds
+              .map(pizzaId => ({
+                ...pizzas.byId[pizzaId],
+                ingredients: pizzas
+                  .byId[pizzaId]
+                  .ingredientsIds
+                  .map(ingredientId => ingredients.byId[ingredientId])
+              }))
+              .filter(p => p.name.toLowerCase().includes(pizzasSearch))
           };
 
           return pizzasCategorie;

--- a/frontend/src/app/shared/states/pizzas/pizzas.interface.ts
+++ b/frontend/src/app/shared/states/pizzas/pizzas.interface.ts
@@ -1,13 +1,19 @@
+import { IIngredientCommon } from 'app/shared/states/ingredients/ingredients.interface';
+
 export interface IPizzaCommon {
   id: string;
   name: string;
-  ingredients: string;
-  prices: [number];
+  ingredientsIds: string[];
+  prices: number[];
 }
 
 export interface IPizzasTable {
   byId: { [key: string]: IPizzaCommon };
   allIds: string[];
+}
+
+export interface IPizzaWithIngredients extends IPizzaCommon {
+  ingredients: IIngredientCommon[];
 }
 
 export interface IPizzaWithPrice extends IPizzaCommon {

--- a/frontend/src/app/shared/states/root.reducer.ts
+++ b/frontend/src/app/shared/states/root.reducer.ts
@@ -10,6 +10,7 @@ import { pizzasReducer } from 'app/shared/states/pizzas/pizzas.reducer';
 import { pizzasCategoriesReducer } from 'app/shared/states/pizzas-categories/pizzas-categories.reducer';
 import { usersReducer } from 'app/shared/states/users/users.reducer';
 import { ordersReducer } from 'app/shared/states/orders/orders.reducer';
+import { ingredientsReducer } from 'app/shared/states/ingredients/ingredients.reducer';
 
 // ------------------------------------------------------------------------------
 
@@ -19,7 +20,8 @@ const reducers = {
   pizzas: pizzasReducer,
   pizzasCategories: pizzasCategoriesReducer,
   users: usersReducer,
-  orders: ordersReducer
+  orders: ordersReducer,
+  ingredients: ingredientsReducer
 };
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Before that PR,  every pizza had a field `ingredients`. It was a simple string, exactly the one on the original pizza provider website.

Now, we have a field `ingredientsIds` and a dedicated part of the store to handle the ingredients.

The idea behind that PR is that we'll be able to make a search by ingredients in a more simple and effective way than looking into a lot of strings (coming from the previous `ingredients`).